### PR TITLE
Granular Verifier functions

### DIFF
--- a/contracts/interfaces/licensing/IParamVerifier.sol
+++ b/contracts/interfaces/licensing/IParamVerifier.sol
@@ -3,7 +3,8 @@
 pragma solidity ^0.8.20;
 
 interface IParamVerifier {
-
-    function verifyParam(address caller, bytes memory value) external view returns (bool);
+    function verifyMintingParam(address caller, uint256 mintAmount, bytes memory data) external returns (bool);
+    function verifyLinkParentParam(address caller, bytes memory data) external returns (bool);
+    function verifyActivationParam(address caller, bytes memory data) external returns (bool);
     function json() external view returns (string memory);
 }

--- a/contracts/registries/LicenseRegistry.sol
+++ b/contracts/registries/LicenseRegistry.sol
@@ -235,9 +235,9 @@ contract LicenseRegistry is ERC1155 {
         for (uint256 i=0; i < mintParams.length; i++) {
             Licensing.Parameter memory param = mintParams[i];
             // Empty bytes => use default value specified in license framework creation params.
-            bytes memory callValue = mintParamValues[i].length == 0 ? param.defaultValue : mintParamValues[i];
+            bytes memory data = mintParamValues[i].length == 0 ? param.defaultValue : mintParamValues[i];
             // TODO: is `caller` param `msg.sender` or `receiver` or something else?
-            if (!param.verifier.verifyParam(receiver, callValue)) {
+            if (!param.verifier.verifyMintingParam(receiver, amount, data)) {
                 revert Errors.LicenseRegistry__MintParamFailed();
             }
         }
@@ -282,14 +282,13 @@ contract LicenseRegistry is ERC1155 {
         
         Licensing.Policy memory pol = policy(licenseData.policyId);
         
-        // TODO: verify the mechanism for checking linking conditions
         Licensing.Parameter[] memory linkParams = _frameworks[pol.frameworkId].linkParentParams;
         bytes[] memory linkParamValues = pol.linkParentParamValues;
         for (uint256 i=0; i < linkParams.length; i++) {
             Licensing.Parameter memory param = linkParams[i];
             // Empty bytes => use default value specified in license framework creation params.
-            bytes memory callValue = linkParamValues[i].length == 0 ? param.defaultValue : linkParamValues[i];
-            if (!param.verifier.verifyParam(holder, callValue)) {
+            bytes memory data = linkParamValues[i].length == 0 ? param.defaultValue : linkParamValues[i];
+            if (!param.verifier.verifyLinkParentParam(holder, data)) {
                 revert Errors.LicenseRegistry__LinkParentParamFailed();
             }
         }

--- a/test/foundry/mocks/licensing/MintPaymentVerifier.sol
+++ b/test/foundry/mocks/licensing/MintPaymentVerifier.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.23;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { IParamVerifier } from "contracts/interfaces/licensing/IParamVerifier.sol";
+
+contract MintPaymentVerifier is IParamVerifier {
+    IERC20 public token;
+    uint256 public payment;
+
+    constructor(address _token, uint256 _payment) {
+        token = IERC20(_token);
+        payment = _payment;
+    }
+
+    /// @dev Mock verifies the param by decoding it as a bool. If you want the verifier
+    /// to return true, pass in abi.encode(true) as the value.
+    function verifyMintingParam(address caller, uint256 mintAmount, bytes memory) external returns (bool) {
+        // TODO: return false on approval or transfer failure
+        require(token.allowance(caller, address(this)) >= payment * mintAmount, "MintPaymentVerifier: Approval");
+        require(token.transferFrom(caller, address(this), payment * mintAmount), "MintPaymentVerifier: Transfer");
+        return true;
+    }
+
+    function verifyLinkParentParam(address, bytes memory) external pure returns (bool) {
+        return true;
+    }
+
+		function verifyActivationParam(address, bytes memory) external pure returns (bool) {
+				return true;
+		}
+
+    function json() external pure returns (string memory) {
+        return "";
+    }
+}

--- a/test/foundry/mocks/licensing/MockParamVerifier.sol
+++ b/test/foundry/mocks/licensing/MockParamVerifier.sol
@@ -1,12 +1,18 @@
 // SPDX-License-Identifier: MIT
-
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.23;
 
 import { IParamVerifier } from "contracts/interfaces/licensing/IParamVerifier.sol";
 
 contract MockIParamVerifier is IParamVerifier {
+    function verifyMintingParam(address, uint256, bytes memory value) external pure returns (bool) {
+        return abi.decode(value, (bool));
+    }
 
-    function verifyParam(address, bytes memory value) external pure returns (bool) {
+    function verifyLinkParentParam(address, bytes memory value) external pure returns (bool) {
+        return abi.decode(value, (bool));
+    }
+
+    function verifyActivationParam(address, bytes memory value) external pure returns (bool) {
         return abi.decode(value, (bool));
     }
 


### PR DESCRIPTION
Divide verifyParam into the three sections that require calling it, so we can pass in different parameters instead of jamming everything (including inputs not specified by users, such as mintAmount) into bytes call data.
```
function verifyMintingParam(address caller, uint256 mintAmount, bytes memory data) external returns (bool);
function verifyLinkParentParam(address caller, bytes memory data) external returns (bool);
function verifyActivationParam(address caller, bytes memory data) external returns (bool);
```