### PR TITLE
AccessController support gobal permission

### DIFF
--- a/contracts/interfaces/IAccessController.sol
+++ b/contracts/interfaces/IAccessController.sol
@@ -14,6 +14,14 @@ interface IAccessController {
     /// @param permission_ The permission level
     function setPermission(address ipAccount_, address signer_, address to_, bytes4 func_, uint8 permission_) external;
 
+    /// @notice Sets the permission for all IPAccounts
+    /// @dev Only the protocol admin can set the global permission
+    /// @param signer_ The account that signs the transaction
+    /// @param to_ The recipient(modules) of the transaction
+    /// @param func_ The function selector
+    /// @param permission_ The permission level
+    function setGlobalPermission(address signer_, address to_, bytes4 func_, uint8 permission_) external;
+
     /// @notice Gets the permission for a specific function call
     /// @param ipAccount_ The account that owns the IP
     /// @param signer_ The account that signs the transaction

--- a/test/foundry/mocks/MockAccessController.sol
+++ b/test/foundry/mocks/MockAccessController.sol
@@ -10,7 +10,10 @@ contract MockAccessController is IAccessController {
     function setAllowed(bool _isAllowed) external {
         isAllowed = _isAllowed;
     }
+    function setGlobalPermission(address signer_, address to_, bytes4 func_, uint8 permission_) external{
 
+    }
+    
     function setPermission(address, address, address, bytes4, uint8) external pure {
 
     }


### PR DESCRIPTION
Add support global permission into AccessController.

It allows protocol admin to set permission to applies to all accounts.
