### PR TITLE
Adds the licensing registry and registration module

### DIFF
--- a/contracts/AccessController.sol
+++ b/contracts/AccessController.sol
@@ -2,6 +2,7 @@
 // See https://github.com/storyprotocol/protocol-contracts/blob/main/StoryProtocol-AlphaTestingAgreement-17942166.3.pdf
 pragma solidity ^0.8.21;
 
+import { IModuleRegistry } from "contracts/interfaces/registries/IModuleRegistry.sol";
 import { IAccessController } from "contracts/interfaces/IAccessController.sol";
 import { IIPAccountRegistry } from "contracts/interfaces/registries/IIPAccountRegistry.sol";
 import { IModuleRegistry } from "contracts/interfaces/registries/IModuleRegistry.sol";
@@ -75,12 +76,12 @@ contract AccessController is IAccessController {
         if (!IIPAccountRegistry(IP_ACCOUNT_REGISTRY).isIpAccount(ipAccount_)) {
             revert Errors.AccessController__IPAccountIsNotValid();
         }
-        if (ipAccount_ != msg.sender) {
-            revert Errors.AccessController__CallerIsNotIPAccount();
-        }
         // permission must be one of ABSTAIN, ALLOW, DENY
         if (permission_ > 2) {
             revert Errors.AccessController__PermissionIsNotValid();
+        }
+        if (!IModuleRegistry(MODULE_REGISTRY).isRegistered(msg.sender) && ipAccount_ != msg.sender) {
+            revert Errors.AccessController__CallerIsNotIPAccount();
         }
         permissions[ipAccount_][signer_][to_][func_] = permission_;
 

--- a/contracts/interfaces/modules/base/IModule.sol
+++ b/contracts/interfaces/modules/base/IModule.sol
@@ -2,6 +2,9 @@
 // See https://github.com/storyprotocol/protocol-contracts/blob/main/StoryProtocol-AlphaTestingAgreement-17942166.3.pdf
 pragma solidity ^0.8.23;
 
+/// @notice Module Interface
 interface IModule {
+
+    /// @notice Returns the string identifier associated with the module.
     function name() external returns (string memory);
 }

--- a/contracts/interfaces/registries/IIPRecordRegistry.sol
+++ b/contracts/interfaces/registries/IIPRecordRegistry.sol
@@ -99,7 +99,7 @@ interface IIPRecordRegistry {
         uint256 tokenId,
         address resolverAddr,
         bool createAccount
-    ) external;
+    ) external returns (address);
 
     /// @notice Creates the IP account for the specified IP.
     /// @param chainId The chain identifier of where the IP resides.

--- a/contracts/interfaces/resolvers/IResolver.sol
+++ b/contracts/interfaces/resolvers/IResolver.sol
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 // See https://github.com/storyprotocol/protocol-contracts/blob/main/StoryProtocol-AlphaTestingAgreement-17942166.3.pdf
-pragma solidity ^0.8.21;
+pragma solidity ^0.8.23;
+
+import { IModule } from "contracts/interfaces/modules/base/IModule.sol";
 
 /// @notice Resolver Interface
-interface IResolver {
-
-    /// @notice Gets the address of the access controller for the resolver.
-    function accessController() view external returns (address);
+interface IResolver is IModule {
 
     /// @notice Checks whether the resolver IP interface is supported.
     function supportsInterface(bytes4 id) view external returns (bool);

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -6,6 +6,13 @@ pragma solidity ^0.8.19;
 /// @notice Library for all Story Protocol contract errors.
 library Errors {
     ////////////////////////////////////////////////////////////////////////////
+    //                                   Module                               //
+    ////////////////////////////////////////////////////////////////////////////
+
+    /// @notice The caller is not allowed to call the provided module.
+    error Module_Unauthorized();
+
+    ////////////////////////////////////////////////////////////////////////////
     //                               IPRecordRegistry                         //
     ////////////////////////////////////////////////////////////////////////////
 
@@ -93,6 +100,13 @@ library Errors {
     error ModuleRegistry__NameAlreadyRegistered();
     error ModuleRegistry__NameDoesNotMatch();
     error ModuleRegistry__ModuleNotRegistered();
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                               RegistrationModule                       //
+    ////////////////////////////////////////////////////////////////////////////
+
+    /// @notice The caller is not the owner of the root IP NFT.
+    error RegistrationModule__InvalidOwner();
 
     ////////////////////////////////////////////////////////////////////////////
     //                             AccessController                           //

--- a/contracts/lib/Licensing.sol
+++ b/contracts/lib/Licensing.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.20;
 import { IParamVerifier } from "../interfaces/licensing/IParamVerifier.sol";
 
 library Licensing {
-
     /// Identifies a license parameter (term) from a license framework
     struct Parameter {
         /// Contract that must check if the condition of the paremeter is set
@@ -51,7 +50,7 @@ library Licensing {
         bytes[] linkParentParamDefaultValues;
         string licenseUrl;
     }
-    
+
     /// A particular configuration of a Licensing Framework, setting (or not) values for the licensing
     /// terms (parameters) of the framework.
     /// The lengths of the param value arrays must correspond to the Parameter[] of the framework.
@@ -66,7 +65,7 @@ library Licensing {
         bytes[] activationParamValues;
         /// If false, minted licenses will start activated and verification of activationParams will be skipped
         bool needsActivation;
-        /// Array with values for parameters verifying conditions to link a license to a parent. Empty bytes for index if
+        /// Array with values for params verifying conditions to link a license to a parent. Empty bytes for index if
         /// this policy wants to use the default value for the paremeter.
         bytes[] linkParentParamValues;
     }

--- a/contracts/lib/modules/Module.sol
+++ b/contracts/lib/modules/Module.sol
@@ -3,4 +3,7 @@
 pragma solidity ^0.8.21;
 
 // String values for core protocol modules.
+string constant METADATA_RESOLVER_MODULE_KEY = "METADATA_RESOLVER_MODULE";
+
+// String values for core protocol modules.
 string constant REGISTRATION_MODULE_KEY = "REGISTRATION_MODULE";

--- a/contracts/modules/BaseModule.sol
+++ b/contracts/modules/BaseModule.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: UNLICENSED
+// See https://github.com/storyprotocol/protocol-contracts/blob/main/StoryProtocol-AlphaTestingAgreement-17942166.3.pdf
+pragma solidity ^0.8.23;
+
+import { IModule } from "contracts/interfaces/modules/base/IModule.sol";
+import { IAccessController } from "contracts/interfaces/IAccessController.sol";
+import { IPRecordRegistry } from "contracts/registries/IPRecordRegistry.sol";
+import { IPAccountRegistry } from "contracts/registries/IPAccountRegistry.sol";
+import { LicenseRegistry } from "contracts/registries/LicenseRegistry.sol";
+import { IResolver } from "contracts/interfaces/resolvers/IResolver.sol";
+import { Errors } from "contracts/lib/Errors.sol";
+
+/// @title BaseModule
+/// @notice Base implementation for all modules in Story Protocol. This is to
+///         ensure all modules share the same authorization through the access
+///         controll manager.
+abstract contract BaseModule is IModule {
+    /// @notice Gets the protocol-wide module access controller.
+    IAccessController public immutable ACCESS_CONTROLLER;
+
+    /// @notice Gets the protocol-wide IP account registry.
+    IPAccountRegistry public immutable IP_ACCOUNT_REGISTRY;
+
+    /// @notice Gets the protocol-wide IP record registry.
+    IPRecordRegistry public immutable IP_RECORD_REGISTRY;
+
+    /// @notice Gets the protocol-wide license registry.
+    LicenseRegistry public immutable LICENSE_REGISTRY;
+
+    /// @notice Modifier for authorizing the calling entity.
+    modifier onlyAuthorized(address ipId) {
+        _authenticate(ipId);
+        _;
+    }
+
+    /// @notice Initializes the base module contract.
+    /// @param controller The access controller used for IP authorization.
+    /// @param recordRegistry The address of the IP record registry.
+    /// @param accountRegistry The address of the IP account registry.
+    /// @param licenseRegistry The address of the license registry.
+    constructor(address controller, address recordRegistry, address accountRegistry, address licenseRegistry) {
+        // TODO: Add checks for interface support or at least zero address
+        ACCESS_CONTROLLER = IAccessController(controller);
+        IP_RECORD_REGISTRY = IPRecordRegistry(recordRegistry);
+        IP_ACCOUNT_REGISTRY = IPAccountRegistry(accountRegistry);
+        LICENSE_REGISTRY = LicenseRegistry(licenseRegistry);
+    }
+
+    /// @notice Gets the protocol string identifier associated with the module.
+    /// @return The string identifier of the module.
+    function name() public pure virtual override returns (string memory);
+
+    /// @notice Authenticates the caller entity through the access controller.
+    function _authenticate(address ipId) internal view {
+        if (!ACCESS_CONTROLLER.checkPermission(ipId, msg.sender, address(this), msg.sig)) {
+            revert Errors.Module_Unauthorized();
+        }
+    }
+}

--- a/contracts/modules/RegistrationModule.sol
+++ b/contracts/modules/RegistrationModule.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: UNLICENSED
+// See https://github.com/storyprotocol/protocol-contracts/blob/main/StoryProtocol-AlphaTestingAgreement-17942166.3.pdf
+pragma solidity ^0.8.23;
+
+import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+import { BaseModule } from "contracts/modules/BaseModule.sol";
+import { IIPMetadataResolver } from "contracts/interfaces/resolvers/IIPMetadataResolver.sol";
+import { REGISTRATION_MODULE_KEY } from "contracts/lib/modules/Module.sol";
+import { Errors } from "contracts/lib/Errors.sol";
+import { IP } from "contracts/lib/IP.sol";
+
+/// @title Registration Module
+/// @notice The registration module is responsible for registration of IP into
+///         the protocol. During registration, this module will register an IP
+///         into the protocol, create a resolver, and bind to it any licenses
+///         and terms specified by the IP registrant (IP account owner).
+contract RegistrationModule is BaseModule {
+    /// @notice The metadata resolver used by the registration module.
+    IIPMetadataResolver public resolver;
+
+    /// @notice Initializes the registration module contract.
+    /// @param controller The access controller used for IP authorization.
+    /// @param recordRegistry The address of the IP record registry.
+    /// @param accountRegistry The address of the IP account registry.
+    /// @param licenseRegistry The address of the license registry.
+    /// @param resolverAddr The address of the IP metadata resolver.
+    constructor(
+        address controller,
+        address recordRegistry,
+        address accountRegistry,
+        address licenseRegistry,
+        address resolverAddr
+    ) BaseModule(controller, recordRegistry, accountRegistry, licenseRegistry) {
+        resolver = IIPMetadataResolver(resolverAddr);
+    }
+
+    /// @notice Registers a root-level IP into the protocol. Root-level IPs can
+    ///         be thought of as organizational hubs for encapsulating policies
+    ///         that actual IPs can use to register through. As such, a
+    ///         root-level IP is not an actual IP, but a container for IP policy
+    ///         management for their child IP assets.
+    /// TODO: Rethink the semantics behind "root-level IPs" vs. "normal IPs".
+    /// TODO: Update function parameters to utilize a struct instead.
+    /// TODO: Revisit requiring binding an existing NFT to a "root-level IP".
+    ///       If root-level IPs are an organizational primitive, why require NFTs?
+    /// TODO: Change to a different resolver optimized for root IP metadata.
+    /// @param policyId The policy that identifies the licensing terms of the IP.
+    /// @param tokenContract The address of the NFT bound to the root-level IP.
+    /// @param tokenId The token id of the NFT bound to the root-level IP.
+    function registerRootIp(uint256 policyId, address tokenContract, uint256 tokenId) external returns (address) {
+        // Perform registrant authorization.
+        // Check that the caller is authorized to perform the registration.
+        // TODO: Perform additional registration authorization logic, allowing
+        //       registrants or root-IP creators to specify their own auth logic.
+        if (IERC721(tokenContract).ownerOf(tokenId) != msg.sender) {
+            revert Errors.RegistrationModule__InvalidOwner();
+        }
+
+        // Perform core IP registration and IP account creation.
+        address ipId = IP_RECORD_REGISTRY.register(block.chainid, tokenContract, tokenId, address(resolver), true);
+
+        // Perform core IP policy creation.
+        if (policyId != 0) {
+            // If we know the policy ID, we can register it directly on creation.
+            // TODO: return policy index
+            LICENSE_REGISTRY.addPolicyToIp(ipId, policyId);
+        }
+
+        return ipId;
+    }
+
+    /// @notice Registers an IP derivative into the protocol.
+    /// @param licenseId The license to incorporate for the new IP.
+    /// @param tokenContract The address of the NFT bound to the derivative IP.
+    /// @param tokenId The token id of the NFT bound to the derivative IP.
+    /// @param ipName The name assigned to the new IP.
+    /// @param ipDescription A string description to assign to the IP.
+    /// @param hash The content hash of the IP being registered.
+    function registerDerivativeIp(
+        uint256 licenseId,
+        address tokenContract,
+        uint256 tokenId,
+        string memory ipName,
+        string memory ipDescription,
+        bytes32 hash
+    ) external {
+        // Check that the caller is authorized to perform the registration.
+        // TODO: Perform additional registration authorization logic, allowing
+        //       registrants or IP creators to specify their own auth logic.
+        if (IERC721(tokenContract).ownerOf(tokenId) != msg.sender) {
+            revert Errors.RegistrationModule__InvalidOwner();
+        }
+
+        // Perform core IP registration and IP account creation.
+        address ipId = IP_RECORD_REGISTRY.register(block.chainid, tokenContract, tokenId, address(resolver), true);
+        ACCESS_CONTROLLER.setPermission(ipId, address(this), address(resolver), IIPMetadataResolver.setMetadata.selector, 1);
+
+        // Perform core IP derivative licensing - the license must be owned by the caller.
+        // TODO: return resulting policy index
+        LICENSE_REGISTRY.linkIpToParent(licenseId, ipId, msg.sender);
+
+        // Perform metadata attribution setting.
+        resolver.setMetadata(
+            ipId,
+            IP.MetadataRecord({
+                name: ipName,
+                description: ipDescription,
+                hash: hash,
+                registrationDate: uint64(block.timestamp),
+                registrant: msg.sender,
+                uri: ""
+            })
+        );
+    }
+
+    /// @notice Gets the protocol-wide module identifier for this module.
+    function name() public pure override returns (string memory) {
+        return REGISTRATION_MODULE_KEY;
+    }
+}

--- a/contracts/resolvers/IPMetadataResolver.sol
+++ b/contracts/resolvers/IPMetadataResolver.sol
@@ -6,10 +6,13 @@ import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { Base64 } from "@openzeppelin/contracts/utils/Base64.sol";
 import { IResolver } from "contracts/interfaces/resolvers/IResolver.sol";
 import { ResolverBase } from "./ResolverBase.sol";
+import { BaseModule } from "contracts/modules/BaseModule.sol";
+import { IModule } from "contracts/interfaces/modules/base/IModule.sol";
 import { IIPMetadataResolver } from "contracts/interfaces/resolvers/IIPMetadataResolver.sol";
 import { IIPAccount } from "contracts/interfaces/IIPAccount.sol";
 import { Errors } from "contracts/lib/Errors.sol";
 import { IP } from "contracts/lib/IP.sol";
+import { METADATA_RESOLVER_MODULE_KEY } from "contracts/lib/modules/Module.sol";
 
 /// @title IP Metadata Resolver
 /// @notice Canonical IP resolver contract used for Story Protocol. This will
@@ -23,11 +26,13 @@ contract IPMetadataResolver is IIPMetadataResolver, ResolverBase {
     /// @param accessController The access controller used for IP authorization.
     /// @param ipRecordRegistry The address of the IP record registry.
     /// @param ipAccountRegistry The address of the IP account registry.
+    /// @param licenseRegistry The address of the license registry.
     constructor(
         address accessController,
         address ipRecordRegistry,
-        address ipAccountRegistry
-    ) ResolverBase(accessController, ipRecordRegistry, ipAccountRegistry) {}
+        address ipAccountRegistry,
+        address licenseRegistry
+    ) ResolverBase(accessController, ipRecordRegistry, ipAccountRegistry, licenseRegistry) {}
 
     /// @notice Fetches all metadata associated with the specified IP.
     /// @param ipId The canonical ID of the specified IP.
@@ -143,6 +148,11 @@ contract IPMetadataResolver is IIPMetadataResolver, ResolverBase {
     /// @return Whether the resolver interface is supported.
     function supportsInterface(bytes4 id) public view virtual override(IResolver, ResolverBase) returns (bool) {
         return id == type(IIPMetadataResolver).interfaceId || super.supportsInterface(id);
+    }
+
+    /// @notice Gets the protocol-wide module identifier for this module.
+    function name() public pure override(BaseModule, IModule) returns (string memory) {
+        return METADATA_RESOLVER_MODULE_KEY;
     }
 
     /// @dev Internal function for generating a default IP URI if not provided.

--- a/contracts/resolvers/ResolverBase.sol
+++ b/contracts/resolvers/ResolverBase.sol
@@ -1,48 +1,19 @@
 // SPDX-License-Identifier: UNLICENSED
 // See https://github.com/storyprotocol/protocol-contracts/blob/main/StoryProtocol-AlphaTestingAgreement-17942166.3.pdf
-pragma solidity ^0.8.21;
+pragma solidity ^0.8.23;
 
-import { IAccessController } from "contracts/interfaces/IAccessController.sol";
-import { IPRecordRegistry } from "contracts/registries/IPRecordRegistry.sol";
-import { IPAccountRegistry } from "contracts/registries/IPAccountRegistry.sol";
+import { BaseModule } from "contracts/modules/BaseModule.sol";
 import { IResolver } from "contracts/interfaces/resolvers/IResolver.sol";
-import { Errors } from "contracts/lib/Errors.sol";
 
 /// @notice IP Resolver Base Contract
-abstract contract ResolverBase is IResolver {
-    /// @notice Gets the protocol-wide module access controller.
-    IAccessController public immutable ACCESS_CONTROLLER;
+abstract contract ResolverBase is IResolver, BaseModule {
 
-    /// @notice Gets the protocol-wide IP account registry.
-    IPAccountRegistry public immutable IP_ACCOUNT_REGISTRY;
-
-    /// @notice Gets the protocol-wide IP record registry.
-    IPRecordRegistry public immutable IP_RECORD_REGISTRY;
-
-    /// @notice Checks if IP identified by ipId is authorized to perform a call.
-    /// @param ipId The identifier for the IP being authorized.
-    modifier onlyAuthorized(address ipId) {
-        if (!ACCESS_CONTROLLER.checkPermission(ipId, msg.sender, address(this), msg.sig)) {
-            revert Errors.IPResolver_Unauthorized();
-        }
-        _;
-    }
-
-    /// @notice Initializes the base IP resolver contract.
-    /// @param controller The address of the module access controller.
+    /// @notice Initializes the base module contract.
+    /// @param controller The access controller used for IP authorization.
     /// @param recordRegistry The address of the IP record registry.
     /// @param accountRegistry The address of the IP account registry.
-    constructor(address controller, address recordRegistry, address accountRegistry) {
-        ACCESS_CONTROLLER = IAccessController(controller);
-        IP_RECORD_REGISTRY = IPRecordRegistry(recordRegistry);
-        IP_ACCOUNT_REGISTRY = IPAccountRegistry(accountRegistry);
-    }
-
-    /// @notice Gets the access controller responsible for resolver auth.
-    /// @return The address of the access controller.
-    function accessController() external view returns (address) {
-        return address(ACCESS_CONTROLLER);
-    }
+    /// @param licenseRegistry The address of the license registry.
+    constructor(address controller, address recordRegistry, address accountRegistry, address licenseRegistry) BaseModule(controller, recordRegistry, accountRegistry, licenseRegistry) {}
 
     /// @notice Checks whether the resolver interface is supported.
     /// @param id The resolver interface identifier.

--- a/test/foundry/AccessController.t.sol
+++ b/test/foundry/AccessController.t.sol
@@ -590,7 +590,6 @@ contract AccessControllerTest is Test {
         );
     }
 
-
     function test_AccessController_functionWildcardOverrideToAddressWildcard_allowOverrideDeny() public {
         moduleRegistry.registerModule("MockModule", address(mockModule));
         address signer = vm.addr(2);

--- a/test/foundry/integration/Integration.t.sol
+++ b/test/foundry/integration/Integration.t.sol
@@ -179,10 +179,9 @@ contract IntegrationTest is Test {
     function attachPolicyToIPID(
         address ipId,
         string memory policyName
-    ) public returns (uint256 policyId, uint256 indexOnIpId) {
-        (policyId, indexOnIpId) = licenseRegistry.addPolicy(ipId, policy[policyName]);
+    ) public returns (uint256 policyId, bool isNew, uint256 indexOnIpId) {
+        (policyId, isNew, indexOnIpId) = licenseRegistry.addPolicyToIp(ipId, policy[policyName]);
         policyIds[policyName][ipId] = policyId;
-        return (policyId, indexOnIpId);
     }
 
     function attachPolicyAndMintLicenseForIPID(
@@ -191,7 +190,7 @@ contract IntegrationTest is Test {
         address licensee,
         uint256 amount
     ) public returns (uint256 licenseId) {
-        (uint256 policyId, uint256 indexOnIpId) = attachPolicyToIPID(ipId, policyName);
+        (uint256 policyId, bool isNew, uint256 indexOnIpId) = attachPolicyToIPID(ipId, policyName);
         Licensing.License memory licenseData = Licensing.License({
             policyId: policyId,
             licensorIpIds: new address[](1)
@@ -330,6 +329,9 @@ contract IntegrationTest is Test {
             linkParentParamValues: new bytes[](0)
         });
 
+        licenseRegistry.addPolicy(policy["test_true"]);
+        licenseRegistry.addPolicy(policy["expensive_mint"]);
+
         /*///////////////////////////////////////////////////////////////
                             ADD POLICIES TO IPACCOUNTS
         ////////////////////////////////////////////////////////////////*/
@@ -361,7 +363,7 @@ contract IntegrationTest is Test {
         // Carl activates above license on his NFT C IPAccount, linking as child to Alice's NFT A IPAccount
 
         vm.prank(u.carl);
-        licenseRegistry.setParentPolicy(
+        licenseRegistry.linkIpToParent(
             licenseIds[u.carl][policyIds["test_true"][getIpId(u.alice, nft.a, 1)]],
             getIpId(u.carl, nft.c, 1),
             u.carl
@@ -414,7 +416,7 @@ contract IntegrationTest is Test {
         // Bob activates above license on his NFT A IPAccount, linking as child to Carl's NFT C IPAccount
 
         vm.prank(u.bob);
-        licenseRegistry.setParentPolicy(
+        licenseRegistry.linkIpToParent(
             licenseIds[u.bob][policyIds["expensive_mint"][getIpId(u.carl, nft.c, 1)]],
             getIpId(u.bob, nft.a, 2),
             u.bob

--- a/test/foundry/modules/ModuleBase.t.sol
+++ b/test/foundry/modules/ModuleBase.t.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import { MockAccessController } from "test/foundry/mocks/MockAccessController.sol";
+import { BaseTest } from "test/foundry/utils/BaseTest.sol";
+import { LicenseRegistry } from "contracts/registries/LicenseRegistry.sol";
+import { IModule } from "contracts/interfaces/modules/base/IModule.sol";
+import { BaseModule } from "contracts/modules/BaseModule.sol";
+import { ModuleRegistry } from "contracts/registries/ModuleRegistry.sol";
+import { AccessController } from "contracts/AccessController.sol";
+import { IAccessController } from "contracts/interfaces/IAccessController.sol";
+import { ERC6551Registry } from "lib/reference/src/ERC6551Registry.sol";
+import { IModuleRegistry } from "contracts/interfaces/registries/IModuleRegistry.sol";
+import { IPRecordRegistry } from "contracts/registries/IPRecordRegistry.sol";
+import { IPAccountRegistry } from "contracts/registries/IPAccountRegistry.sol";
+import { MockModuleRegistry } from "test/foundry/mocks/MockModuleRegistry.sol";
+import { IIPRecordRegistry } from "contracts/interfaces/registries/IIPRecordRegistry.sol";
+import { IPAccountImpl} from "contracts/IPAccountImpl.sol";
+import { IIPMetadataResolver } from "contracts/interfaces/resolvers/IIPMetadataResolver.sol";
+import { MockERC721 } from "test/foundry/mocks/MockERC721.sol";
+import { IP } from "contracts/lib/IP.sol";
+import { Errors } from "contracts/lib/Errors.sol";
+
+/// @title Module Base Test Contract
+/// @notice Base contract for testing standard module functionality.
+abstract contract ModuleBaseTest is BaseTest {
+
+    /// @notice Gets the protocol-wide license registry.
+    LicenseRegistry public licenseRegistry;
+
+    /// @notice The access controller address.
+    AccessController public accessController;
+
+    /// @notice Gets the protocol-wide IP account registry.
+    IPAccountRegistry public ipAccountRegistry;
+
+    /// @notice Gets the protocol-wide IP record registry.
+    IPRecordRegistry public ipRecordRegistry;
+
+    /// @notice Gets the protocol-wide module registry.
+    ModuleRegistry public moduleRegistry;
+
+    /// @notice The module SUT.
+    IModule public baseModule;
+
+    /// @notice Initializes the base module for testing.
+    function setUp() public virtual override(BaseTest) {
+        BaseTest.setUp();
+        licenseRegistry = new LicenseRegistry("");
+        accessController = new AccessController();
+        moduleRegistry = new ModuleRegistry();
+        ipAccountRegistry = new IPAccountRegistry(
+            address(new ERC6551Registry()),
+            address(accessController),
+            address(new IPAccountImpl())
+        );
+        accessController.initialize(address(ipAccountRegistry), address(moduleRegistry));
+        ipRecordRegistry = new IPRecordRegistry(
+            address(moduleRegistry),
+            address(ipAccountRegistry)
+        );
+        baseModule = IModule(_deployModule());
+    }
+
+    /// @notice Tests that the default resolver constructor runs successfully.
+    function test_Module_Name() public {
+        assertEq(baseModule.name(), _expectedName());
+    }
+
+    /// @dev Deploys the module SUT.
+    function _deployModule() internal virtual returns (address);
+
+    /// @dev Gets the expected name for the module.
+    function _expectedName() internal virtual view returns (string memory);
+
+}

--- a/test/foundry/modules/RegistrationModule.t.sol
+++ b/test/foundry/modules/RegistrationModule.t.sol
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import { MockAccessController } from "test/foundry/mocks/MockAccessController.sol";
+import { BaseTest } from "test/foundry/utils/BaseTest.sol";
+import { IModule } from "contracts/interfaces/modules/base/IModule.sol";
+import { ModuleBaseTest } from "./ModuleBase.t.sol";
+import { IPAccountChecker } from "contracts/lib/registries/IPAccountChecker.sol";
+import { IAccessController } from "contracts/interfaces/IAccessController.sol";
+import { ERC6551Registry } from "lib/reference/src/ERC6551Registry.sol";
+import { ModuleRegistry } from "contracts/registries/ModuleRegistry.sol";
+import { IModuleRegistry } from "contracts/interfaces/registries/IModuleRegistry.sol";
+import { IPRecordRegistry } from "contracts/registries/IPRecordRegistry.sol";
+import { IPAccountRegistry } from "contracts/registries/IPAccountRegistry.sol";
+import { IPMetadataResolver } from "contracts/resolvers/IPMetadataResolver.sol";
+import { RegistrationModule } from "contracts/modules/RegistrationModule.sol";
+import { MockModuleRegistry } from "test/foundry/mocks/MockModuleRegistry.sol";
+import { IIPRecordRegistry } from "contracts/interfaces/registries/IIPRecordRegistry.sol";
+import { IPAccountImpl} from "contracts/IPAccountImpl.sol";
+import { IIPMetadataResolver } from "contracts/interfaces/resolvers/IIPMetadataResolver.sol";
+import { MockERC721 } from "test/foundry/mocks/MockERC721.sol";
+import { IParamVerifier } from "contracts/interfaces/licensing/IParamVerifier.sol";
+import { MockIParamVerifier } from "test/foundry/mocks/licensing/MockParamVerifier.sol";
+import { Licensing } from "contracts/lib/Licensing.sol";
+import { IP } from "contracts/lib/IP.sol";
+import { Errors } from "contracts/lib/Errors.sol";
+import { METADATA_RESOLVER_MODULE_KEY, REGISTRATION_MODULE_KEY } from "contracts/lib/modules/Module.sol";
+import { IIPAccount } from "contracts/interfaces/IIPAccount.sol";
+
+/// @title IP Registration Module Test Contract
+/// @notice Tests IP registration module functionality.
+contract RegistrationModuleTest is ModuleBaseTest {
+
+    // Default IP record attributes.
+    string public constant RECORD_NAME = "IPRecord";
+    string public constant RECORD_DESCRIPTION = "IPs all the way down.";
+    bytes32 public constant RECORD_HASH = "";
+
+    /// @notice The registration module SUT.
+    RegistrationModule public registrationModule;
+
+    /// @notice Gets the IP metadata resolver tied to the registration module.
+    IIPMetadataResolver public resolver;
+
+    /// @notice Mock NFT address for IP registration testing.
+    address public tokenAddress;
+
+    /// @notice Mock NFT tokenId for IP registration testing.
+    uint256 public tokenId;
+
+    /// @notice Alternative NFT tokenId for IP registration testing.
+    uint256 public tokenId2;
+
+    /// @notice Policy Id with mocked terms for IP registration testing.
+    uint256 public policyId;
+
+    /// @notice Initializes the base token contract for testing.
+    function setUp() public virtual override(ModuleBaseTest) {
+        ModuleBaseTest.setUp();
+        _initLicensing();
+        resolver = new IPMetadataResolver(
+            address(accessController),
+            address(ipRecordRegistry),
+            address(ipAccountRegistry),
+            address(licenseRegistry)
+        );
+        registrationModule = RegistrationModule(_deployModule());
+        moduleRegistry.registerModule(REGISTRATION_MODULE_KEY, address(registrationModule));
+        moduleRegistry.registerModule(METADATA_RESOLVER_MODULE_KEY, address(resolver));
+        MockERC721 erc721 = new MockERC721();
+        tokenAddress = address(erc721);
+        tokenId = erc721.mintId(alice, 99);
+        tokenId2 = erc721.mintId(bob, 100);
+    }
+
+    /// @notice Checks that the registration initialization operates correctly.
+    function test_RegistrationModule_Constructor() public {
+        assertEq(address(registrationModule.ACCESS_CONTROLLER()), address(accessController));
+        assertEq(address(registrationModule.IP_ACCOUNT_REGISTRY()), address(ipAccountRegistry));
+        assertEq(address(registrationModule.IP_RECORD_REGISTRY()), address(ipRecordRegistry));
+        assertEq(address(registrationModule.LICENSE_REGISTRY()), address(licenseRegistry));
+        assertEq(address(registrationModule.resolver()), address(resolver));
+    }
+
+    /// @notice Checks whether root IP registration operates as expected.
+    function test_RegistrationModule_RegisterRootIP() public {
+        uint256 totalSupply = ipRecordRegistry.totalSupply();
+        address ipId = ipRecordRegistry.ipId(block.chainid, tokenAddress, tokenId);
+
+        // Ensure unregistered IP preconditions are satisfied.
+        assertTrue(!ipRecordRegistry.isRegistered(ipId));
+        assertTrue(!ipRecordRegistry.isRegistered(block.chainid, tokenAddress, tokenId));
+        assertTrue(!IPAccountChecker.isRegistered(ipAccountRegistry, block.chainid, tokenAddress, tokenId));
+        
+        vm.startPrank(alice);
+        registrationModule.registerRootIp(
+            policyId,
+            tokenAddress,
+            tokenId
+        );
+        vm.stopPrank();
+
+        /// Ensure registered IP postconditiosn are met.
+        assertEq(ipRecordRegistry.resolver(ipId), address(resolver));
+        assertEq(totalSupply + 1, ipRecordRegistry.totalSupply());
+        assertTrue(ipRecordRegistry.isRegistered(ipId));
+        assertTrue(ipRecordRegistry.isRegistered(block.chainid, tokenAddress, tokenId));
+        assertTrue(IPAccountChecker.isRegistered(ipAccountRegistry, block.chainid, tokenAddress, tokenId));
+    }
+
+    /// @notice Checks that registration reverts when called by an invalid owner.
+    function test_RegistrationModule_RegisterRootIP_Reverts_InvalidOwner() public {
+        vm.expectRevert(Errors.RegistrationModule__InvalidOwner.selector);
+        registrationModule.registerRootIp(
+            0,
+            tokenAddress,
+            tokenId
+        );
+    }
+
+    /// @notice Checks whether root IP registration operates as expected.
+    function test_RegistrationModule_RegisterDerivativeIP() public {
+        // Register root IP with policyId
+        vm.prank(alice);
+        address ipId = registrationModule.registerRootIp(
+            policyId,
+            tokenAddress,
+            tokenId
+        );
+
+        // Mint license
+        Licensing.License memory licenseData = Licensing.License({
+            policyId: policyId,
+            licensorIpIds: new address[](1)
+        });
+        licenseData.licensorIpIds[0] = ipId;
+        uint256 licenseId = licenseRegistry.mintLicense(licenseData, 1, bob);
+        uint256 totalSupply = ipRecordRegistry.totalSupply();
+        
+
+        // Ensure unregistered IP preconditions are satisfied.
+        address ipId2 = ipRecordRegistry.ipId(block.chainid, tokenAddress, tokenId2);
+
+        assertFalse(ipRecordRegistry.isRegistered(ipId2), "IP is already registered");
+        assertFalse(ipRecordRegistry.isRegistered(block.chainid, tokenAddress, tokenId2), "IP is already registered");
+        assertFalse(IPAccountChecker.isRegistered(ipAccountRegistry, block.chainid, tokenAddress, tokenId2), "IP is already registered");
+
+        vm.prank(bob);
+        registrationModule.registerDerivativeIp(
+            licenseId,
+            tokenAddress,
+            tokenId2,
+            RECORD_NAME,
+            RECORD_DESCRIPTION,
+            RECORD_HASH
+        );
+
+
+        /// Ensur registered IP post-conditions are met.
+        assertEq(ipRecordRegistry.resolver(ipId2), address(resolver));
+        assertEq(totalSupply + 1, ipRecordRegistry.totalSupply());
+        assertTrue(ipRecordRegistry.isRegistered(ipId2));
+        assertTrue(ipRecordRegistry.isRegistered(block.chainid, tokenAddress, tokenId2));
+        assertEq(resolver.name(ipId2), RECORD_NAME);
+        assertEq(resolver.description(ipId2), RECORD_DESCRIPTION);
+        assertEq(resolver.hash(ipId2), RECORD_HASH);
+        assertEq(resolver.owner(ipId2), bob);
+    }
+
+    /// @notice Checks that registration reverts when called by an invalid owner.
+    function test_RegistrationModule_ARegisterDerivativeIP_Reverts_InvalidOwner() public {
+        vm.expectRevert(Errors.RegistrationModule__InvalidOwner.selector);
+        registrationModule.registerDerivativeIp(
+            0,
+            tokenAddress,
+            tokenId,
+            RECORD_NAME,
+            RECORD_DESCRIPTION,
+            RECORD_HASH
+        );
+    }
+
+    /// @dev Deploys the registration module SUT.
+    function _deployModule() internal virtual override returns (address) {
+        return address(
+            new RegistrationModule(
+                address(accessController),
+                address(ipRecordRegistry),
+                address(ipAccountRegistry),
+                address(licenseRegistry),
+                address(resolver)
+            )
+        );
+    }
+
+    /// @dev Gets the expected name for the module.
+    function _expectedName() internal virtual view override returns (string memory) {
+        return "REGISTRATION_MODULE";
+    }
+
+    // TODO: put this in the base test
+    function _initLicensing() private {
+        IParamVerifier[] memory mintingParamVerifiers = new IParamVerifier[](1);
+        MockIParamVerifier verifier = new MockIParamVerifier();
+        mintingParamVerifiers[0] = verifier;
+        bytes[] memory mintingParamDefaultValues = new bytes[](1);
+        mintingParamDefaultValues[0] = abi.encode(true);
+        IParamVerifier[] memory activationParamVerifiers = new IParamVerifier[](1);
+        activationParamVerifiers[0] = verifier;
+        bytes[] memory activationParamDefaultValues = new bytes[](1);
+        activationParamDefaultValues[0] = abi.encode(true);
+        IParamVerifier[] memory linkParentParamVerifiers = new IParamVerifier[](1);
+        linkParentParamVerifiers[0] = verifier;
+        bytes[] memory linkParentParamDefaultValues = new bytes[](1);
+        linkParentParamDefaultValues[0] = abi.encode(true);
+
+        Licensing.FrameworkCreationParams memory fwParams = Licensing.FrameworkCreationParams({
+            mintingParamVerifiers: mintingParamVerifiers,
+            mintingParamDefaultValues: mintingParamDefaultValues,
+            activationParamVerifiers: activationParamVerifiers,
+            activationParamDefaultValues: activationParamDefaultValues,
+            defaultNeedsActivation: true,
+            linkParentParamVerifiers: linkParentParamVerifiers,
+            linkParentParamDefaultValues: linkParentParamDefaultValues,
+            licenseUrl: "https://example.com"
+        });
+        licenseRegistry.addLicenseFramework(fwParams);
+        Licensing.Policy memory policy = Licensing.Policy({
+            frameworkId: 1,
+            mintingParamValues: new bytes[](1),
+            activationParamValues: new bytes[](1),
+            needsActivation: false,
+            linkParentParamValues: new bytes[](1)
+        });
+        policy.mintingParamValues[0] = abi.encode(true);
+        policy.activationParamValues[0] = abi.encode(true);
+        policy.linkParentParamValues[0] = abi.encode(true);
+        (uint256 polId, bool isNew) = licenseRegistry.addPolicy(policy);
+        
+        policyId = polId;
+    }
+
+}

--- a/test/foundry/resolvers/IPMetadataResolver.t.sol
+++ b/test/foundry/resolvers/IPMetadataResolver.t.sol
@@ -10,14 +10,17 @@ import { IResolver } from "contracts/interfaces/resolvers/IResolver.sol";
 import { ERC6551Registry } from "lib/reference/src/ERC6551Registry.sol";
 import { IModuleRegistry } from "contracts/interfaces/registries/IModuleRegistry.sol";
 import { IPRecordRegistry } from "contracts/registries/IPRecordRegistry.sol";
+import { RegistrationModule } from "contracts/modules/RegistrationModule.sol";
 import { IPAccountRegistry } from "contracts/registries/IPAccountRegistry.sol";
 import { MockModuleRegistry } from "test/foundry/mocks/MockModuleRegistry.sol";
 import { IIPRecordRegistry } from "contracts/interfaces/registries/IIPRecordRegistry.sol";
 import { IPAccountImpl} from "contracts/IPAccountImpl.sol";
 import { IIPMetadataResolver } from "contracts/interfaces/resolvers/IIPMetadataResolver.sol";
 import { MockERC721 } from "test/foundry/mocks/MockERC721.sol";
+import { ModuleBaseTest } from "test/foundry/modules/ModuleBase.t.sol";
 import { IP } from "contracts/lib/IP.sol";
 import { Errors } from "contracts/lib/Errors.sol";
+import { METADATA_RESOLVER_MODULE_KEY, REGISTRATION_MODULE_KEY } from "contracts/lib/modules/Module.sol";
 
 /// @title IP Metadata Resolver Test Contract
 /// @notice Tests IP metadata resolver functionality.
@@ -30,14 +33,8 @@ contract IPMetadataResolverTest is ResolverBaseTest {
     uint64 public constant RECORD_REGISTRATION_DATE = 999999;
     string public constant RECORD_URI = "https://storyprotocol.xyz";
 
-    /// @notice Placeholder for registration module.
-    address public registrationModule = vm.addr(0x1337);
-
-    /// @notice The IP record registry.
-    IPRecordRegistry public registry;
-
-    /// @notice The IP account registry.
-    IPAccountRegistry public ipAccountRegistry;
+    /// @notice The registration module.
+    address public registrationModule;
 
     /// @notice The token contract SUT.
     IIPMetadataResolver public ipResolver;
@@ -48,22 +45,22 @@ contract IPMetadataResolverTest is ResolverBaseTest {
     /// @notice Initializes the base token contract for testing.
     function setUp() public virtual override(ResolverBaseTest) {
         ResolverBaseTest.setUp();
-        ipAccountRegistry = new IPAccountRegistry(
-            address(new ERC6551Registry()),
-            address(accessController),
-            address(new IPAccountImpl())
-        );
-        registry = new IPRecordRegistry(
-            address(new MockModuleRegistry(registrationModule)),
-            address(ipAccountRegistry)
-        );
         MockERC721 erc721 = new MockERC721();
         vm.prank(alice);
-        ipResolver = IIPMetadataResolver(_deployResolver());
+        ipResolver = IIPMetadataResolver(_deployModule());
         uint256 tokenId = erc721.mintId(alice, 99);
-        ipId = registry.ipId(block.chainid, address(erc721), tokenId);
+        // TODO: Mock this correctly
+        registrationModule = address(new RegistrationModule(
+            address(accessController),
+            address(ipRecordRegistry),
+            address(ipAccountRegistry),
+            address(licenseRegistry),
+            address(ipResolver)
+        ));
+        moduleRegistry.registerModule(REGISTRATION_MODULE_KEY, registrationModule);
+        moduleRegistry.registerModule(METADATA_RESOLVER_MODULE_KEY, address(ipResolver));
         vm.prank(registrationModule);
-        registry.register(
+        ipId = ipRecordRegistry.register(
             block.chainid,
             address(erc721),
             tokenId,
@@ -79,6 +76,7 @@ contract IPMetadataResolverTest is ResolverBaseTest {
 
     /// @notice Tests that metadata may be properly set for the resolver.
     function test_IPMetadataResolver_SetMetadata() public {
+        vm.prank(ipId);
         accessController.setPermission(ipId, alice, address(ipResolver), IIPMetadataResolver.setMetadata.selector, 1);
         vm.prank(alice);
         ipResolver.setMetadata(
@@ -113,7 +111,7 @@ contract IPMetadataResolverTest is ResolverBaseTest {
 
     /// @notice Checks that an unauthorized call to setMetadata reverts.
     function test_IPMetadataResolver_SetMetadata_Reverts_Unauthorized() public {
-        vm.expectRevert(Errors.IPResolver_Unauthorized.selector);
+        vm.expectRevert(Errors.Module_Unauthorized.selector);
         ipResolver.setMetadata(
             ipId,
             IP.MetadataRecord({
@@ -129,6 +127,7 @@ contract IPMetadataResolverTest is ResolverBaseTest {
 
     /// @notice Tests that the name may be properly set for the resolver.
     function test_IPMetadataResolver_SetName() public {
+        vm.prank(ipId);
         accessController.setPermission(ipId, alice, address(ipResolver), IIPMetadataResolver.setName.selector, 1);
         vm.prank(alice);
         ipResolver.setName(ipId, RECORD_NAME);
@@ -137,12 +136,13 @@ contract IPMetadataResolverTest is ResolverBaseTest {
 
     /// @notice Checks that an unauthorized call to setName reverts.
     function test_IPMetadataResolver_SetName_Reverts_Unauthorized() public {
-        vm.expectRevert(Errors.IPResolver_Unauthorized.selector);
+        vm.expectRevert(Errors.Module_Unauthorized.selector);
         ipResolver.setName(ipId, RECORD_NAME);
     }
 
     /// @notice Tests that the description may be properly set for the resolver.
-    function test_IPMetadataResolver_SetDescription() public {
+    function test_IPMetadataResolver_SetDescriptionx() public {
+        vm.prank(ipId);
         accessController.setPermission(ipId, alice, address(ipResolver), IIPMetadataResolver.setDescription.selector, 1);
         vm.prank(alice);
         ipResolver.setDescription(ipId, RECORD_DESCRIPTION);
@@ -151,12 +151,13 @@ contract IPMetadataResolverTest is ResolverBaseTest {
 
     /// @notice Checks that an unauthorized call to setDescription reverts.
     function test_IPMetadataResolver_SetDescription_Reverts_Unauthorized() public {
-        vm.expectRevert(Errors.IPResolver_Unauthorized.selector);
+        vm.expectRevert(Errors.Module_Unauthorized.selector);
         ipResolver.setDescription(ipId, RECORD_DESCRIPTION);
     }
 
     /// @notice Tests that the hash may be properly set for the resolver.
     function test_IPMetadataResolver_SetHash() public {
+        vm.prank(ipId);
         accessController.setPermission(ipId, alice, address(ipResolver), IIPMetadataResolver.setHash.selector, 1);
         vm.prank(alice);
         ipResolver.setHash(ipId, RECORD_HASH);
@@ -165,7 +166,7 @@ contract IPMetadataResolverTest is ResolverBaseTest {
 
     /// @notice Checks that an unauthorized call to setHash reverts.
     function test_IPMetadataResolver_SetHash_Reverts_Unauthorized() public {
-        vm.expectRevert(Errors.IPResolver_Unauthorized.selector);
+        vm.expectRevert(Errors.Module_Unauthorized.selector);
         ipResolver.setHash(ipId, RECORD_HASH);
     }
 
@@ -178,6 +179,7 @@ contract IPMetadataResolverTest is ResolverBaseTest {
 
     /// @notice Checks setting token URI works as expected.
     function test_IPMetadataResolver_SetTokenURI() public {
+        vm.prank(ipId);
         accessController.setPermission(ipId, alice, address(ipResolver), IIPMetadataResolver.setURI.selector, 1);
         vm.prank(alice);
         ipResolver.setURI(ipId, RECORD_URI);
@@ -221,13 +223,19 @@ contract IPMetadataResolverTest is ResolverBaseTest {
         assertEq(expectedURI, ipResolver.uri(ipId));
     }
 
+    /// @dev Gets the expected name for the module.
+    function _expectedName() internal virtual view override returns (string memory) {
+        return "METADATA_RESOLVER_MODULE";
+    }
+
     /// @dev Deploys a new IP Metadata Resolver.
-    function _deployResolver() internal override returns (address) {
+    function _deployModule() internal override returns (address) {
         return address(
             new IPMetadataResolver(
                 address(accessController),
-                address(registry),
-                address(ipAccountRegistry)
+                address(ipRecordRegistry),
+                address(ipAccountRegistry),
+                address(licenseRegistry)
             )
         );
     }

--- a/test/foundry/resolvers/ResolverBase.t.sol
+++ b/test/foundry/resolvers/ResolverBase.t.sol
@@ -1,42 +1,28 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
-import "forge-std/console2.sol";
-
 import { MockAccessController } from "test/foundry/mocks/MockAccessController.sol";
-import { BaseTest } from "test/foundry/utils/BaseTest.sol";
+import { ModuleBaseTest } from "test/foundry/modules/ModuleBase.t.sol";
 import { IResolver } from "contracts/interfaces/resolvers/IResolver.sol";
 import { IAccessController } from "contracts/interfaces/IAccessController.sol";
 import { Errors } from "contracts/lib/Errors.sol";
 
 /// @title Resolver Base Test Contract
 /// @notice Base contract for testing standard resolver functionality.
-abstract contract ResolverBaseTest is BaseTest {
-
-    /// @notice The access controller address.
-    IAccessController public accessController;
+abstract contract ResolverBaseTest is ModuleBaseTest {
 
     /// @notice The resolver SUT.
     IResolver public baseResolver;
 
     /// @notice Initializes the base ERC20 contract for testing.
-    function setUp() public virtual override(BaseTest) {
-        BaseTest.setUp();
-        accessController = IAccessController(address(new MockAccessController()));
-        baseResolver = IResolver(_deployResolver());
-    }
-
-    /// @notice Tests that the default resolver constructor runs successfully.
-    function test_Resolver_Constructor() public {
-        assertEq(baseResolver.accessController(), address(accessController));
+    function setUp() public virtual override(ModuleBaseTest) {
+        ModuleBaseTest.setUp();
+        baseResolver = IResolver(_deployModule());
     }
 
     /// @notice Tests that the base resolver interface is supported.
     function test_Resolver_SupportsInterface() public virtual {
         assertTrue(baseResolver.supportsInterface(type(IResolver).interfaceId));
     }
-
-    /// @dev Deploys the resolver SUT.
-    function _deployResolver() internal virtual returns (address);
 
 }


### PR DESCRIPTION
This PR adds the following changes:
- Incorporation of the registration module as the gateway to IP registration
- Inclusion of the license registry, with functions centered around IP registry, root and derivative IP creation
- Revamp of the IP metadata resolver to extend the base module, so that authorization works with the access controller