### PR TITLE
Identify provenance of license policies added to IP ids

### DIFF
--- a/contracts/interfaces/registries/ILicenseRegistry.sol
+++ b/contracts/interfaces/registries/ILicenseRegistry.sol
@@ -12,7 +12,7 @@ interface ILicenseRegistry {
 
     event PolicyCreated(address indexed creator, uint256 indexed policyId, Licensing.Policy policy);
 
-    event PolicyAddedToIpId(address indexed caller, address indexed ipId, uint256 indexed policyId);
+    event PolicyAddedToIpId(address indexed caller, address indexed ipId, uint256 indexed policyId, bool setByLinking);
 
     event LicenseMinted(
         address indexed creator,
@@ -55,6 +55,7 @@ interface ILicenseRegistry {
     function frameworkParams(uint256 frameworkId, Licensing.ParamVerifierType pvt) external view returns (Licensing.Parameter[] memory);
     function frameworkUrl(uint256 frameworkId) external view returns (string memory);
 
+
     function totalPolicies() external view returns (uint256);
 
     function policy(uint256 policyId) external view returns (Licensing.Policy memory pol);
@@ -70,6 +71,8 @@ interface ILicenseRegistry {
     function policyIdForIpAtIndex(address ipId, uint256 index) external view returns (uint256 policyId);
 
     function policyForIpAtIndex(address ipId, uint256 index) external view returns (Licensing.Policy memory);
+
+    function isPolicyIdAtIndexSetByLinking(address ipId, uint256 index) external view returns (bool);
 
     function isLicensee(uint256 licenseId, address holder) external view returns (bool);
 

--- a/contracts/registries/LicenseRegistry.sol
+++ b/contracts/registries/LicenseRegistry.sol
@@ -26,6 +26,9 @@ contract LicenseRegistry is ERC1155, ILicenseRegistry {
     uint256 private _totalPolicies;
     // DO NOT remove policies, that rugs derivatives and breaks ordering assumptions in set
     mapping(address => EnumerableSet.UintSet) private _policiesPerIpId;
+    //
+    mapping(address => bool[]) private _policyPerIpIdSetByLinking;
+
     mapping(address => EnumerableSet.AddressSet) private _ipIdParents;
 
     mapping(bytes32 => uint256) private _hashedLicenses;
@@ -168,7 +171,7 @@ contract LicenseRegistry is ERC1155, ILicenseRegistry {
     ) public returns (uint256 policyId, bool isNew, uint256 indexOnIpId) {
         // check protocol auth
         (uint256 polId, bool newPolicy) = _addPolicy(pol);
-        return (polId, newPolicy, _addPolictyIdToIp(ipId, polId));
+        return (polId, newPolicy, _addPolictyIdToIp(ipId, polId, false));
     }
 
     /// Adds a policy to an ipId, which can be used to mint licenses.
@@ -182,7 +185,7 @@ contract LicenseRegistry is ERC1155, ILicenseRegistry {
         if (!isPolicyDefined(polId)) {
             revert Errors.LicenseRegistry__PolicyNotFound();
         }
-        return _addPolictyIdToIp(ipId, polId);
+        return _addPolictyIdToIp(ipId, polId, false);
     }
 
     function addPolicy(Licensing.Policy memory pol) public returns (uint256 policyId) {
@@ -209,14 +212,16 @@ contract LicenseRegistry is ERC1155, ILicenseRegistry {
     /// Will revert if policy set already has policyId
     /// @param ipId the IP identifier
     /// @param policyId id of the policy data
+    /// @param setByLinking true if set in linkIpToParent, false otherwise
     /// @return index of the policy added to the set
-    function _addPolictyIdToIp(address ipId, uint256 policyId) internal returns (uint256 index) {
+    function _addPolictyIdToIp(address ipId, uint256 policyId, bool setByLinking) internal returns (uint256 index) {
         EnumerableSet.UintSet storage policySet = _policiesPerIpId[ipId];
         // TODO: check if policy is compatible with the others
         if (!policySet.add(policyId)) {
             revert Errors.LicenseRegistry__PolicyAlreadySetForIpId();
         }
-        emit PolicyAddedToIpId(msg.sender, ipId, policyId);
+        _policyPerIpIdSetByLinking[ipId].push(setByLinking);
+        emit PolicyAddedToIpId(msg.sender, ipId, policyId, setByLinking);
         return policySet.length() - 1;
     }
 
@@ -259,6 +264,10 @@ contract LicenseRegistry is ERC1155, ILicenseRegistry {
 
     function policyForIpAtIndex(address ipId, uint256 index) external view returns (Licensing.Policy memory) {
         return _policies[_policiesPerIpId[ipId].at(index)];
+    }
+
+    function isPolicyIdAtIndexSetByLinking(address ipId, uint256 index) external view returns (bool) {
+        return _policyPerIpIdSetByLinking[ipId][index];
     }
 
     /// Mints license NFTs representing a policy granted by a set of ipIds (licensors). This NFT needs to be burned
@@ -352,8 +361,8 @@ contract LicenseRegistry is ERC1155, ILicenseRegistry {
         _verifyParams(Licensing.ParamVerifierType.LinkParent, pol, holder, 1);
         
         // Add policy to kid
-        // TODO: return this values
-        addPolicyToIp(childIpId, pol);
+        // TODO: return index of policy in ipId?
+        _addPolictyIdToIp(childIpId, licenseData.policyId, true);
         // Set parent
         for (uint256 i = 0; i < parents.length; i++) {
             // We don't care if it was already a parent, because there might be a case such as:

--- a/test/foundry/LicenseRegistry.t.sol
+++ b/test/foundry/LicenseRegistry.t.sol
@@ -144,6 +144,7 @@ contract LicenseRegistryTest is Test {
         (uint256 policyId, bool isNew, uint256 indexOnIpId) = registry.addPolicyToIp(ipId1, policy);
         assertEq(policyId, 1, "policyId not 1");
         assertEq(indexOnIpId, 0, "indexOnIpId not 0");
+        assertFalse(registry.isPolicyIdAtIndexSetByLinking(ipId1, 0));
         Licensing.Policy memory storedPolicy = registry.policy(policyId);
         assertEq(keccak256(abi.encode(storedPolicy)), keccak256(abi.encode(policy)), "policy not stored properly");
     }
@@ -155,9 +156,11 @@ contract LicenseRegistryTest is Test {
         (uint256 policyId, bool isNew1, uint256 indexOnIpId) = registry.addPolicyToIp(ipId1, policy);
         assertTrue(isNew1, "not new");
         assertEq(indexOnIpId, 0);
+        assertFalse(registry.isPolicyIdAtIndexSetByLinking(ipId1, 0));
         (uint256 policyId2, bool isNew2, uint256 indexOnIpId2) = registry.addPolicyToIp(ipId2, policy);
         assertFalse(isNew2, "new");
         assertEq(indexOnIpId2, 0);
+        assertFalse(registry.isPolicyIdAtIndexSetByLinking(ipId2, 0));
         assertEq(policyId, policyId2, "policyId not reused");
     }
 
@@ -178,6 +181,7 @@ contract LicenseRegistryTest is Test {
         assertEq(registry.totalPolicies(), 1, "totalPolicies not incremented");
         assertEq(registry.totalPoliciesForIp(ipId1), 1, "totalPoliciesForIp not incremented");
         assertEq(registry.policyIdForIpAtIndex(ipId1, 0), 1, "policyIdForIpAtIndex not 1");
+        assertFalse(registry.isPolicyIdAtIndexSetByLinking(ipId1, 0));
 
         // Adding different policy to same ipId
         policy.mintingParamValues[0] = abi.encode("test2");
@@ -188,6 +192,7 @@ contract LicenseRegistryTest is Test {
         assertEq(registry.totalPolicies(), 2, "totalPolicies not incremented");
         assertEq(registry.totalPoliciesForIp(ipId1), 2, "totalPoliciesForIp not incremented");
         assertEq(registry.policyIdForIpAtIndex(ipId1, 1), 2, "policyIdForIpAtIndex not 2");
+        assertFalse(registry.isPolicyIdAtIndexSetByLinking(ipId1, 1));
     }
 
     function test_LicenseRegistry_mintLicense()
@@ -216,7 +221,7 @@ contract LicenseRegistryTest is Test {
         return licenseId;
     }
 
-    function test_LicenseRegistry_setParentId() public {
+    function test_LicenseRegistry_linkIpToParent() public {
         // TODO: something cleaner than this
         uint256 licenseId = test_LicenseRegistry_mintLicense();
 
@@ -228,6 +233,8 @@ contract LicenseRegistryTest is Test {
             keccak256(abi.encode(registry.policyForIpAtIndex(ipId1, 0))),
             "policy not copied"
         );
+        assertEq(registry.policyIdForIpAtIndex(ipId2, 0), 1);
+        assertTrue(registry.isPolicyIdAtIndexSetByLinking(ipId2, 0), "not set by linking?");
 
         address[] memory parents = registry.parentIpIds(ipId2);
         assertEq(parents.length, 1, "not 1 parent");


### PR DESCRIPTION
This difference is useful for license compatibility and derivation.

We add to LicenseRegistry:
```
mapping(address => bool[]) private _policyPerIpIdSetByLinking;
event PolicyAddedToIpId(address indexed caller, address indexed ipId, uint256 indexed policyId, bool setByLinking);
function isPolicyIdAtIndexSetByLinking(address ipId, uint256 index) external view returns (bool);
```
Set By linking `true` means the policy was inherited from parent Ip Id.