### PR TITLE
Fixes external import of ERC-6551 reference to use remapping

### DIFF
--- a/contracts/interfaces/IIPAccount.sol
+++ b/contracts/interfaces/IIPAccount.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.23;
 
 import { IERC721Receiver } from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import { IERC1155Receiver } from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
-import { IERC6551Account } from "lib/reference/src/interfaces/IERC6551Account.sol";
+import { IERC6551Account } from "@reference/src/interfaces/IERC6551Account.sol";
 
 /// @title IIPAccount
 /// @dev IPAccount is a token-bound account that adopts the EIP-6551 standard.


### PR DESCRIPTION
This PR fixes a bug that causes build conflicts due to ambiguous imports of the reference package.