### PR TITLE
Ignore lib folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ typechain
 
 # converage
 lcov.info
+
+# forge lib folder
+lib/


### PR DESCRIPTION
We removed `/lib` from the folder structure, but we were missing the addition to `.gitignore`