### PR TITLE
Prevent ignore of nested lib folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,4 @@ typechain
 lcov.info
 
 # forge lib folder
-lib/
+/lib/


### PR DESCRIPTION
Currently, we are not actually including the nested lib folder into version control. This is preventing external imports of this repo from working.