### PR TITLE
Switches remaining absolute imports to relative imports

### DIFF
--- a/contracts/interfaces/IAccessController.sol
+++ b/contracts/interfaces/IAccessController.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 // See https://github.com/storyprotocol/protocol-contracts/blob/main/StoryProtocol-AlphaTestingAgreement-17942166.3.pdf
 pragma solidity ^0.8.23;
-import { AccessPermission } from "contracts/lib/AccessPermission.sol";
+
+import { AccessPermission } from "../lib/AccessPermission.sol";
 
 interface IAccessController {
     event PermissionSet(

--- a/contracts/interfaces/resolvers/IResolver.sol
+++ b/contracts/interfaces/resolvers/IResolver.sol
@@ -2,7 +2,7 @@
 // See https://github.com/storyprotocol/protocol-contracts/blob/main/StoryProtocol-AlphaTestingAgreement-17942166.3.pdf
 pragma solidity ^0.8.23;
 
-import { IModule } from "contracts/interfaces/modules/base/IModule.sol";
+import { IModule } from "../modules/base/IModule.sol";
 
 /// @notice Resolver Interface
 interface IResolver is IModule {

--- a/contracts/registries/IPAssetRegistry.sol
+++ b/contracts/registries/IPAssetRegistry.sol
@@ -12,7 +12,7 @@ import { IMetadataProviderMigratable } from "../interfaces/registries/metadata/I
 import { MetadataProviderV1 } from "../registries/metadata/MetadataProviderV1.sol";
 import { Errors } from "../lib/Errors.sol";
 import { IResolver } from "../interfaces/resolvers/IResolver.sol";
-import { LICENSING_MODULE_KEY } from "contracts/lib/modules/Module.sol";
+import { LICENSING_MODULE_KEY } from "../lib/modules/Module.sol";
 import { IModuleRegistry } from "../interfaces/registries/IModuleRegistry.sol";
 import { ILicensingModule } from "../interfaces/modules/licensing/ILicensingModule.sol";
 import { IIPAssetRegistry } from "../interfaces/registries/IIPAssetRegistry.sol";

--- a/contracts/registries/ModuleRegistry.sol
+++ b/contracts/registries/ModuleRegistry.sol
@@ -2,13 +2,13 @@
 // See https://github.com/storyprotocol/protocol-contracts/blob/main/StoryProtocol-AlphaTestingAgreement-17942166.3.pdf
 pragma solidity ^0.8.23;
 
+import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 
 import { IModuleRegistry } from "../interfaces/registries/IModuleRegistry.sol";
 import { Errors } from "../lib/Errors.sol";
 import { IModule } from "../interfaces/modules/base/IModule.sol";
 import { Governable } from "../governance/Governable.sol";
-import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import { MODULE_TYPE_DEFAULT } from "../lib/modules/Module.sol";
 
 /// @title ModuleRegistry

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,6 +1,5 @@
 @ethereum-waffle/=node_modules/@ethereum-waffle/
 @openzeppelin/=node_modules/@openzeppelin/
-@erc6551/=node_modules/erc6551/
 forge-std/=node_modules/forge-std/src/
 ds-test/=node_modules/ds-test/src/
 base64-sol/=node_modules/base64-sol/

--- a/test/foundry/AccessController.t.sol
+++ b/test/foundry/AccessController.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.23;
 
 import { Test } from "forge-std/Test.sol";
 
-import { ERC6551Registry } from "@erc6551/ERC6551Registry.sol";
+import { ERC6551Registry } from "erc6551/ERC6551Registry.sol";
 
 import { AccessController } from "contracts/AccessController.sol";
 import { IIPAccount } from "contracts/interfaces/IIPAccount.sol";

--- a/test/foundry/IPAccount.t.sol
+++ b/test/foundry/IPAccount.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
-import { ERC6551Registry } from "@erc6551/ERC6551Registry.sol";
-import { IERC6551Account } from "@erc6551/interfaces/IERC6551Account.sol";
+import { ERC6551Registry } from "erc6551/ERC6551Registry.sol";
+import { IERC6551Account } from "erc6551/interfaces/IERC6551Account.sol";
 import { Test } from "forge-std/Test.sol";
 
 import { IPAccountImpl } from "contracts/IPAccountImpl.sol";

--- a/test/foundry/IPAccountMetaTx.t.sol
+++ b/test/foundry/IPAccountMetaTx.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
-import { ERC6551Registry } from "@erc6551/ERC6551Registry.sol";
+import { ERC6551Registry } from "erc6551/ERC6551Registry.sol";
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import { Test } from "forge-std/Test.sol";
 

--- a/test/foundry/access/AccessControlled.t.sol
+++ b/test/foundry/access/AccessControlled.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.23;
 
 import { Test } from "forge-std/Test.sol";
 
-import { ERC6551Registry } from "@erc6551/ERC6551Registry.sol";
+import { ERC6551Registry } from "erc6551/ERC6551Registry.sol";
 
 import { AccessController } from "contracts/AccessController.sol";
 import { IIPAccount } from "contracts/interfaces/IIPAccount.sol";

--- a/test/foundry/governance/Governance.t.sol
+++ b/test/foundry/governance/Governance.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.23;
 
 import { Test } from "forge-std/Test.sol";
 
-import { ERC6551Registry } from "@erc6551/ERC6551Registry.sol";
+import { ERC6551Registry } from "erc6551/ERC6551Registry.sol";
 
 import { AccessController } from "contracts/AccessController.sol";
 import { IIPAccount } from "contracts/interfaces/IIPAccount.sol";

--- a/test/foundry/integration/BaseIntegration.t.sol
+++ b/test/foundry/integration/BaseIntegration.t.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.23;
 
 // external
-import { IERC6551Registry } from "@erc6551/interfaces/IERC6551Registry.sol";
-import { ERC6551AccountLib } from "@erc6551/lib/ERC6551AccountLib.sol";
+import { IERC6551Registry } from "erc6551/interfaces/IERC6551Registry.sol";
+import { ERC6551AccountLib } from "erc6551/lib/ERC6551AccountLib.sol";
 import { IERC1155 } from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 

--- a/test/foundry/modules/dispute/ArbitrationPolicySP.t.sol
+++ b/test/foundry/modules/dispute/ArbitrationPolicySP.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.23;
 // external
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
-import { ERC6551AccountLib } from "@erc6551/lib/ERC6551AccountLib.sol";
+import { ERC6551AccountLib } from "erc6551/lib/ERC6551AccountLib.sol";
 // contracts
 import { Errors } from "contracts/lib/Errors.sol";
 import { ArbitrationPolicySP } from "contracts/modules/dispute-module/policies/ArbitrationPolicySP.sol";

--- a/test/foundry/modules/dispute/DisputeModule.t.sol
+++ b/test/foundry/modules/dispute/DisputeModule.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.23;
 // external
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
-import { ERC6551AccountLib } from "@erc6551/lib/ERC6551AccountLib.sol";
+import { ERC6551AccountLib } from "erc6551/lib/ERC6551AccountLib.sol";
 // contracts
 import { Errors } from "contracts/lib/Errors.sol";
 import { IModule } from "contracts/interfaces/modules/base/IModule.sol";

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.23;
 // external
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { Test } from "forge-std/Test.sol";
-import { ERC6551Registry } from "@erc6551/ERC6551Registry.sol";
+import { ERC6551Registry } from "erc6551/ERC6551Registry.sol";
 
 // contracts
 import { IPAccountImpl } from "contracts/IPAccountImpl.sol";

--- a/test/foundry/modules/royalty/LSClaimer.t.sol
+++ b/test/foundry/modules/royalty/LSClaimer.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.23;
 // external
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
-import { ERC6551AccountLib } from "@erc6551/lib/ERC6551AccountLib.sol";
+import { ERC6551AccountLib } from "erc6551/lib/ERC6551AccountLib.sol";
 
 // contracts
 import { Errors } from "contracts/lib/Errors.sol";

--- a/test/foundry/registries/IPAccountRegistry.t.sol
+++ b/test/foundry/registries/IPAccountRegistry.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.23;
 
 import { Test } from "forge-std/Test.sol";
 
-import { ERC6551Registry } from "@erc6551/ERC6551Registry.sol";
+import { ERC6551Registry } from "erc6551/ERC6551Registry.sol";
 
 import { IPAccountImpl } from "contracts/IPAccountImpl.sol";
 import { IPAccountChecker } from "contracts/lib/registries/IPAccountChecker.sol";

--- a/test/foundry/utils/DeployHelper.t.sol
+++ b/test/foundry/utils/DeployHelper.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.23;
 
 // external
 import { console2 } from "forge-std/console2.sol"; // console to indicate mock deployment calls.
-import { ERC6551Registry } from "@erc6551/ERC6551Registry.sol";
+import { ERC6551Registry } from "erc6551/ERC6551Registry.sol";
 
 // contracts
 import { AccessController } from "../../../contracts/AccessController.sol";


### PR DESCRIPTION
This PR fixes the remaining absolute imports used in the `contracts` folder to use relative imports. This change is needed to ensure users who import our package externally do not run into any import issues.