### PR TITLE
Removes the module interface from the resolver interface

### DIFF
--- a/contracts/interfaces/resolvers/IResolver.sol
+++ b/contracts/interfaces/resolvers/IResolver.sol
@@ -2,10 +2,8 @@
 // See https://github.com/storyprotocol/protocol-contracts/blob/main/StoryProtocol-AlphaTestingAgreement-17942166.3.pdf
 pragma solidity ^0.8.23;
 
-import { IModule } from "../modules/base/IModule.sol";
-
 /// @notice Resolver Interface
-interface IResolver is IModule {
+interface IResolver {
     /// @notice Checks whether the resolver IP interface is supported.
     function supportsInterface(bytes4 id) external view returns (bool);
 }


### PR DESCRIPTION
The resolver interface itself should not inherit the `IModule` interface since we should not assume that all resolves are modules. Note that in the future we will likely deprecate resolvers altogether anyway.

However, more interesting to note is that this was causing build failures for downstream contracts, as the `ResolverBase` was not properly making explicit from which contract the `name()` (main function provided by `IModule`) was being inherited from.