### PR TITLE
Add permissions for the IPA registry to call `linkParentToIp` in the licensing module

### DIFF
--- a/script/foundry/deployment/Main.s.sol
+++ b/script/foundry/deployment/Main.s.sol
@@ -308,6 +308,13 @@ contract Main is Script, BroadcastManager, JsonDeploymentHandler {
         accessController.initialize(address(ipAccountRegistry), address(moduleRegistry));
 
         accessController.setGlobalPermission(
+            address(ipAssetRegistry),
+            address(licensingModule),
+            bytes4(licensingModule.linkIpToParents.selector),
+            AccessPermission.ALLOW
+        );
+
+        accessController.setGlobalPermission(
             address(registrationModule),
             address(licensingModule),
             bytes4(licensingModule.linkIpToParents.selector),


### PR DESCRIPTION
This change ensures that the IPA registry has permissions to call the licensing module's `linkParentToIp` function, so that when users perform derivative registration via the IPA registry, the registry will be allowed to link the derivative IPA to its parent.