### PR TITLE
Restore MockTokenManagementModule.sol for AccessController Testing

### DIFF
--- a/test/foundry/AccessController.t.sol
+++ b/test/foundry/AccessController.t.sol
@@ -4,11 +4,10 @@ pragma solidity ^0.8.23;
 import { IIPAccount } from "../../contracts/interfaces/IIPAccount.sol";
 import { AccessPermission } from "../../contracts/lib/AccessPermission.sol";
 import { Errors } from "../../contracts/lib/Errors.sol";
-import { TOKEN_WITHDRAWAL_MODULE_KEY } from "../../contracts/lib/modules/Module.sol";
-import { TokenWithdrawalModule } from "../../contracts/modules/external/TokenWithdrawalModule.sol";
 
 import { MockModule } from "./mocks/module/MockModule.sol";
 import { MockOrchestratorModule } from "./mocks/module/MockOrchestratorModule.sol";
+import { MockTokenManagementModule } from "./mocks/module/MockTokenManagementModule.sol";
 import { MockERC1155 } from "./mocks/token/MockERC1155.sol";
 import { MockERC20 } from "./mocks/token/MockERC20.sol";
 import { BaseTest } from "./utils/BaseTest.t.sol";
@@ -1527,11 +1526,12 @@ contract AccessControllerTest is BaseTest {
 
         address anotherAccount = vm.addr(3);
 
-        TokenWithdrawalModule tokenWithdrawalModule = new TokenWithdrawalModule(
+        MockTokenManagementModule tokenManagementModule = new MockTokenManagementModule(
             address(accessController),
-            address(ipAccountRegistry)
+            address(ipAccountRegistry),
+            address(moduleRegistry)
         );
-        moduleRegistry.registerModule(TOKEN_WITHDRAWAL_MODULE_KEY, address(tokenWithdrawalModule));
+        moduleRegistry.registerModule("MockTokenManagementModule", address(tokenManagementModule));
         vm.prank(owner);
         ipAccount.execute(
             address(accessController),
@@ -1539,7 +1539,7 @@ contract AccessControllerTest is BaseTest {
             abi.encodeWithSignature(
                 "setPermission(address,address,address,bytes4,uint8)",
                 address(ipAccount),
-                address(tokenWithdrawalModule),
+                address(tokenManagementModule),
                 address(mockNFT),
                 mockNFT.transferFrom.selector,
                 AccessPermission.ALLOW
@@ -1548,15 +1548,20 @@ contract AccessControllerTest is BaseTest {
         assertEq(
             accessController.getPermission(
                 address(ipAccount),
-                address(tokenWithdrawalModule),
+                address(tokenManagementModule),
                 address(mockNFT),
                 mockNFT.transferFrom.selector
             ),
             AccessPermission.ALLOW
         );
         vm.prank(owner);
-        tokenWithdrawalModule.withdrawERC721(payable(address(ipAccount)), address(mockNFT), tokenId);
-        assertEq(mockNFT.ownerOf(tokenId), owner);
+        tokenManagementModule.transferERC721Token(
+            payable(address(ipAccount)),
+            anotherAccount,
+            address(mockNFT),
+            tokenId
+        );
+        assertEq(mockNFT.ownerOf(tokenId), anotherAccount);
     }
 
     // ipAccount transfer ERC1155 to another account
@@ -1567,11 +1572,12 @@ contract AccessControllerTest is BaseTest {
 
         address anotherAccount = vm.addr(3);
 
-        TokenWithdrawalModule tokenWithdrawalModule = new TokenWithdrawalModule(
+        MockTokenManagementModule tokenManagementModule = new MockTokenManagementModule(
             address(accessController),
-            address(ipAccountRegistry)
+            address(ipAccountRegistry),
+            address(moduleRegistry)
         );
-        moduleRegistry.registerModule(TOKEN_WITHDRAWAL_MODULE_KEY, address(tokenWithdrawalModule));
+        moduleRegistry.registerModule("MockTokenManagementModule", address(tokenManagementModule));
         vm.prank(owner);
         ipAccount.execute(
             address(accessController),
@@ -1579,7 +1585,7 @@ contract AccessControllerTest is BaseTest {
             abi.encodeWithSignature(
                 "setPermission(address,address,address,bytes4,uint8)",
                 address(ipAccount),
-                address(tokenWithdrawalModule),
+                address(tokenManagementModule),
                 address(mock1155),
                 mock1155.safeTransferFrom.selector,
                 AccessPermission.ALLOW
@@ -1588,15 +1594,21 @@ contract AccessControllerTest is BaseTest {
         assertEq(
             accessController.getPermission(
                 address(ipAccount),
-                address(tokenWithdrawalModule),
+                address(tokenManagementModule),
                 address(mock1155),
                 mock1155.safeTransferFrom.selector
             ),
             AccessPermission.ALLOW
         );
         vm.prank(owner);
-        tokenWithdrawalModule.withdrawERC1155(payable(address(ipAccount)), address(mock1155), tokenId, 1e18);
-        assertEq(mock1155.balanceOf(owner, tokenId), 1e18);
+        tokenManagementModule.transferERC1155Token(
+            payable(address(ipAccount)),
+            anotherAccount,
+            address(mock1155),
+            tokenId,
+            1e18
+        );
+        assertEq(mock1155.balanceOf(anotherAccount, tokenId), 1e18);
     }
     // ipAccount transfer ERC20 to another account
     function test_AccessController_ERC20Transfer() public {
@@ -1605,11 +1617,12 @@ contract AccessControllerTest is BaseTest {
 
         address anotherAccount = vm.addr(3);
 
-        TokenWithdrawalModule tokenWithdrawalModule = new TokenWithdrawalModule(
+        MockTokenManagementModule tokenManagementModule = new MockTokenManagementModule(
             address(accessController),
-            address(ipAccountRegistry)
+            address(ipAccountRegistry),
+            address(moduleRegistry)
         );
-        moduleRegistry.registerModule(TOKEN_WITHDRAWAL_MODULE_KEY, address(tokenWithdrawalModule));
+        moduleRegistry.registerModule("MockTokenManagementModule", address(tokenManagementModule));
         vm.prank(owner);
         ipAccount.execute(
             address(accessController),
@@ -1617,7 +1630,7 @@ contract AccessControllerTest is BaseTest {
             abi.encodeWithSignature(
                 "setPermission(address,address,address,bytes4,uint8)",
                 address(ipAccount),
-                address(tokenWithdrawalModule),
+                address(tokenManagementModule),
                 address(mock20),
                 mock20.transfer.selector,
                 AccessPermission.ALLOW
@@ -1626,14 +1639,14 @@ contract AccessControllerTest is BaseTest {
         assertEq(
             accessController.getPermission(
                 address(ipAccount),
-                address(tokenWithdrawalModule),
+                address(tokenManagementModule),
                 address(mock20),
                 mock20.transfer.selector
             ),
             AccessPermission.ALLOW
         );
         vm.prank(owner);
-        tokenWithdrawalModule.withdrawERC20(payable(address(ipAccount)), address(mock20), 1e18);
-        assertEq(mock20.balanceOf(owner), 1e18);
+        tokenManagementModule.transferERC20Token(payable(address(ipAccount)), anotherAccount, address(mock20), 1e18);
+        assertEq(mock20.balanceOf(anotherAccount), 1e18);
     }
 }

--- a/test/foundry/mocks/module/MockTokenManagementModule.sol
+++ b/test/foundry/mocks/module/MockTokenManagementModule.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+
+import { IIPAccount } from "../../../../contracts/interfaces/IIPAccount.sol";
+import { IModule } from "../../../../contracts/interfaces/modules/base/IModule.sol";
+import { IModuleRegistry } from "../../../../contracts/interfaces/registries/IModuleRegistry.sol";
+import { IIPAccountRegistry } from "../../../../contracts/interfaces/registries/IIPAccountRegistry.sol";
+import { IPAccountChecker } from "../../../../contracts/lib/registries/IPAccountChecker.sol";
+import { BaseModule } from "../../../../contracts/modules/BaseModule.sol";
+import { AccessControlled } from "../../../../contracts/access/AccessControlled.sol";
+
+contract MockTokenManagementModule is BaseModule, AccessControlled {
+    using ERC165Checker for address;
+    using IPAccountChecker for IIPAccountRegistry;
+
+    IModuleRegistry public moduleRegistry;
+
+    constructor(
+        address _accessController,
+        address _ipAccountRegistry,
+        address _moduleRegistry
+    ) AccessControlled(_accessController, _ipAccountRegistry) {
+        moduleRegistry = IModuleRegistry(_moduleRegistry);
+    }
+
+    function name() external pure returns (string memory) {
+        return "MockTokenManagementModule";
+    }
+
+    function transferERC721Token(
+        address payable ipAccount,
+        address to,
+        address tokenContract,
+        uint256 tokenId
+    ) external verifyPermission(ipAccount) {
+        IIPAccount(ipAccount).execute(
+            tokenContract,
+            0,
+            abi.encodeWithSignature("transferFrom(address,address,uint256)", ipAccount, to, tokenId)
+        );
+    }
+
+    // transfer ERC1155 token
+    function transferERC1155Token(
+        address payable ipAccount,
+        address to,
+        address tokenContract,
+        uint256 tokenId,
+        uint256 amount
+    ) external verifyPermission(ipAccount) {
+        IIPAccount(ipAccount).execute(
+            tokenContract,
+            0,
+            abi.encodeWithSignature(
+                "safeTransferFrom(address,address,uint256,uint256,bytes)",
+                ipAccount,
+                to,
+                tokenId,
+                amount,
+                ""
+            )
+        );
+    }
+
+    // transfer ERC20 token
+    function transferERC20Token(
+        address payable ipAccount,
+        address to,
+        address tokenContract,
+        uint256 amount
+    ) external verifyPermission(ipAccount) {
+        IIPAccount(ipAccount).execute(
+            tokenContract,
+            0,
+            abi.encodeWithSignature("transfer(address,uint256)", to, amount)
+        );
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return interfaceId == type(IModule).interfaceId || super.supportsInterface(interfaceId);
+    }
+}


### PR DESCRIPTION
This PR for recovering dropped `MockTokenManagementModule.sol` back, it was removed in the last PR #131.
We need to test AccessController support external contract call, while `TokenWithdrawalModule` will be moved to the Periphery repo. 