### PR TITLE
Updates package.json to reflect latest beta release candidate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@story-protocol/contracts",
-  "version": "0.3.0",
-  "description": "Story Protocol smart contracts",
+  "name": "@story-protocol/protocol-core",
+  "version": "v1.0.0-beta-rc6",
+  "description": "Story Protocol core smart contracts",
   "main": "",
   "directories": {
     "lib": "lib",


### PR DESCRIPTION
This change ensures `package.json` has its version set to our latest beta release candidate. In the future, we should make sure the npm version is the same as that of the version declared in `package.json`